### PR TITLE
Don't cfg by OS when an os-agnostic impl exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ name = "clear-cache"
 version = "0.1.2"
 dependencies = [
  "libc",
- "windows",
+ "windows-sys",
 ]
 
 [[package]]
@@ -17,147 +17,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-implement"
-version = "0.60.0"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ categories = ["no-std"]
 [badges]
 maintenance = { status = "actively-developed" }
 
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+# Only pull in OS libraries on platforms where we don't have an ASM implementation
+
+[target.'cfg(all(not(any(target_arch="x86",target_arch="x86_64",target_arch="loongarch64")),any(target_os="linux", target_os="android")))'.dependencies]
 libc = { version = "0.2", default-features = false }
 
-[target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.61", features = [
+[target.'cfg(all(not(any(target_arch="x86",target_arch="x86_64",target_arch="loongarch64")),target_os="windows"))'.dependencies]
+windows-sys = { version = "0.61", features = [
   "Win32_System_Threading",
   "Win32_System_Diagnostics_Debug",
 ] }

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,0 +1,70 @@
+//! Implementations of os_arch_clear_cache for architectures where it can be done without
+//! calling into the operating system.
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(crate) unsafe fn os_arch_clear_cache<T>(_start: *const T, _end: *const T) -> bool {
+    // Intel processors have a unified instruction and data cache so there is nothing to do
+    true
+}
+
+#[cfg(target_arch = "loongarch64")]
+pub(crate) unsafe fn os_arch_clear_cache<T>(_start: *const T, _end: *const T) -> bool {
+    unsafe {
+        core::arch::asm!("ibar 0");
+    }
+    true
+}
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) unsafe fn os_arch_clear_cache<T>(start: *const T, end: *const T) -> bool {
+    let start = start as u64;
+    let end = end as u64;
+
+    let mut ctr_el0: u64;
+    // Get Cache Type Info.
+    unsafe {
+        core::arch::asm!("mrs {0}, ctr_el0", out(reg) ctr_el0);
+    }
+
+    // If CTR_EL0.IDC is set, data cache cleaning to the point of unification
+    // is not required for instruction to data coherence.
+    if ((ctr_el0 >> 28) & 0x1) == 0x0 {
+        let dcache_line_size = 4 << ((ctr_el0 >> 16) & 15);
+        let mut addr = start & !(dcache_line_size - 1);
+        while addr < end {
+            unsafe {
+                core::arch::asm!(
+                    "dc cvau, {0}",
+                    in(reg) addr,
+                );
+            }
+            addr += dcache_line_size;
+        }
+    }
+    unsafe {
+        core::arch::asm!("dsb ish");
+    }
+    // If CTR_EL0.DIC is set, instruction cache invalidation to the point of
+    // unification is not required for instruction to data coherence.
+    if ((ctr_el0 >> 29) & 0x1) == 0x0 {
+        let icache_line_size = 4 << ((ctr_el0 >> 0) & 15);
+        let mut addr = start & !(icache_line_size - 1);
+        while addr < end {
+            unsafe {
+                core::arch::asm!(
+                    "ic ivau, {0}",
+                    in(reg) addr,
+                );
+            }
+            addr += icache_line_size;
+        }
+        unsafe {
+            core::arch::asm!("dsb ish");
+        }
+    }
+    unsafe {
+        core::arch::asm!("isb sy");
+    }
+
+    true
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,23 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
-mod linux;
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use linux::*;
-
-#[cfg(target_os = "windows")]
-mod windows;
-#[cfg(target_os = "windows")]
-use windows::*;
-
-#[cfg(target_os = "macos")]
-mod macos;
-#[cfg(target_os = "macos")]
-use macos::*;
+#[cfg_attr(
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "loongarch64",
+    ),
+    path = "arch.rs"
+)]
+#[cfg_attr(
+    not(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "loongarch64",
+    )),
+    path = "os.rs"
+)]
+mod clear_cache_impl;
 
 /// Flush CPU's instruction cache at given range.
 ///
@@ -26,5 +29,5 @@ use macos::*;
 /// instructions and syscalls make it difficult to guarantee that this function is totally
 /// safe.
 pub unsafe fn clear_cache<T>(start: *const T, end: *const T) -> bool {
-    os_arch_clear_cache(start, end)
+    clear_cache_impl::os_arch_clear_cache(start, end)
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,12 +1,7 @@
 #[cfg(target_arch = "arm")]
 pub(crate) unsafe fn os_arch_clear_cache<T>(start: *const T, end: *const T) -> bool {
     const __ARM_NR_CACHEFLUSH: i32 = 0x0f0002;
-    let res = libc::syscall(
-        __ARM_NR_CACHEFLUSH,
-        start as usize as u64,
-        end as usize as u64,
-        0,
-    );
+    let res = libc::syscall(__ARM_NR_CACHEFLUSH, start as usize, end as usize, 0);
     res == 0
 }
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,70 +1,3 @@
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub(crate) unsafe fn os_arch_clear_cache<T>(_start: *const T, _end: *const T) -> bool {
-    // Intel processors have a unified instruction and data cache so there is nothing to do
-    true
-}
-
-#[cfg(target_arch = "loongarch64")]
-pub(crate) unsafe fn os_arch_clear_cache<T>(start: *const T, end: *const T) -> bool {
-    unsafe {
-        core::arch::asm!("ibar 0");
-    }
-    true
-}
-
-#[cfg(target_arch = "aarch64")]
-pub(crate) unsafe fn os_arch_clear_cache<T>(start: *const T, end: *const T) -> bool {
-    let start = start as u64;
-    let end = end as u64;
-
-    let mut ctr_el0: u64;
-    // Get Cache Type Info.
-    unsafe {
-        core::arch::asm!("mrs {0}, ctr_el0", out(reg) ctr_el0);
-    }
-
-    // If CTR_EL0.IDC is set, data cache cleaning to the point of unification
-    // is not required for instruction to data coherence.
-    if ((ctr_el0 >> 28) & 0x1) == 0x0 {
-        let dcache_line_size = 4 << ((ctr_el0 >> 16) & 15);
-        let mut addr = start & !(dcache_line_size - 1);
-        while addr < end {
-            unsafe {
-                core::arch::asm!(
-                    "dc cvau, {0}",
-                    in(reg) addr,
-                );
-            }
-            addr += dcache_line_size;
-        }
-    }
-    unsafe {
-        core::arch::asm!("dsb ish");
-    }
-    // If CTR_EL0.DIC is set, instruction cache invalidation to the point of
-    // unification is not required for instruction to data coherence.
-    if ((ctr_el0 >> 29) & 0x1) == 0x0 {
-        let icache_line_size = 4 << ((ctr_el0 >> 0) & 15);
-        let mut addr = start & !(icache_line_size - 1);
-        while addr < end {
-            unsafe {
-                core::arch::asm!(
-                    "ic ivau, {0}",
-                    in(reg) addr,
-                );
-            }
-            addr += icache_line_size;
-        }
-        unsafe {
-            core::arch::asm!("dsb ish");
-        }
-    }
-    unsafe {
-        core::arch::asm!("isb sy");
-    }
-
-    true
-}
 #[cfg(target_arch = "arm")]
 pub(crate) unsafe fn os_arch_clear_cache<T>(start: *const T, end: *const T) -> bool {
     const __ARM_NR_CACHEFLUSH: i32 = 0x0f0002;
@@ -91,3 +24,9 @@ pub(crate) unsafe fn os_arch_clear_cache<T>(start: *const T, end: *const T) -> b
     };
     res == 0
 }
+
+// On aarch64 linux, there is no cache invalidation syscall. Use the asm implementation.
+#[cfg(target_arch = "aarch64")]
+mod arch;
+#[cfg(target_arch = "aarch64")]
+pub(crate) use arch::os_arch_clear_cache;

--- a/src/os.rs
+++ b/src/os.rs
@@ -1,0 +1,10 @@
+//! Implementations of os_arch_clear_cache for architectures where it is (or may be) a
+//! privileged operation that requires calling into the operating system.
+
+#[cfg_attr(any(target_os = "linux", target_os = "android"), path = "linux.rs")]
+#[cfg_attr(target_os = "windows", path = "windows.rs")]
+#[cfg_attr(target_os = "macos", path = "macos.rs")]
+#[cfg_attr(target_os = "none", path = "arch.rs")]
+mod clear_cache_impl;
+
+pub(crate) use clear_cache_impl::os_arch_clear_cache;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,4 @@
-use windows::Win32::System::{
+use windows_sys::Win32::System::{
     Diagnostics::Debug::FlushInstructionCache, Threading::GetCurrentProcess,
 };
 
@@ -6,9 +6,9 @@ pub(crate) unsafe fn os_arch_clear_cache<T>(start: *const T, end: *const T) -> b
     let res = unsafe {
         FlushInstructionCache(
             GetCurrentProcess(),
-            Some(start.cast()),
+            start.cast(),
             (end as *const u8).offset_from(start as *const u8) as usize,
         )
     };
-    res.is_ok()
+    res != 0
 }


### PR DESCRIPTION
Restructures the crate so that it does not depend on operating system APIs or rely on `target_os` cfgs when the CPU architecture allows implementing `clear_cache` directly.

This means that for such platforms (`x86`, `x86_64`, `aarch64` and `loongarch64`), the crate has zero dependencies and will compile on all operating systems as well as bare metal targets.

I have also replaced the `windows` dependency by `windows-sys`, since `windows` is heavier and pulls proc macro dependencies that `clear-cache` doesn't use. This should not really matter, though, since all Windows-supported architectures (x86, x86_64 and aarch64) can implement `clear_cache` without calling into the OS.

Finally, since it is a small change and making it as a separate PR would conflict with this one, I also fixed #3.